### PR TITLE
Find/update/delete by type

### DIFF
--- a/lib/graphvix/callbacks.ex
+++ b/lib/graphvix/callbacks.ex
@@ -4,20 +4,25 @@ defmodule Graphvix.Callbacks do
     quote do
       @empty_graph %{nodes: %{}, edges: %{}, clusters: %{}, attrs: []}
 
+      # load
       def handle_cast({:load, new_graph}, _graph) do
         {:noreply, new_graph}
       end
+      # reset
       def handle_cast(:reset, _graph) do
         {:noreply, @empty_graph}
       end
+      # save as txt
       def handle_cast({:save, filename, :txt}, graph) do
         File.write(filename <> ".txt", inspect(graph))
         {:noreply, graph}
       end
+      # save as dot
       def handle_cast({:save, filename, :dot}, graph) do
         File.write(filename <> ".dot", Graphvix.Writer.write(graph))
         {:noreply, graph}
       end
+      # update element
       def handle_cast({:update, id, attrs}, graph) do
         new_graph = case kind_of_element(graph, id) do
           :node -> update_attrs_for_element_in_graph(graph, id, Map.get(graph.nodes, id), :nodes, attrs)
@@ -26,50 +31,56 @@ defmodule Graphvix.Callbacks do
         end
         {:noreply, new_graph}
       end
+      # update graph
       def handle_cast({:update, attrs}, graph) do
         new_graph = %{ graph | attrs: merge_without_nils(graph.attrs, attrs) }
         {:noreply, new_graph}
       end
 
-      def handle_cast({:remove, id}, graph) do
-        new_graph = case kind_of_element(graph, id) do
-          nil -> graph
-          :cluster -> update_graph_with_element_removed(graph, :clusters, id)
-          :edge -> update_graph_with_element_removed(graph, :edges, id)
-          :node ->
-            graph
-            |> remove_edges_attached_to_node(id)
-            |> remove_node_from_clusters(id)
-            |> update_graph_with_element_removed(:nodes, id)
-        end
-        {:noreply, new_graph}
-      end
 
+      # find
+      def handle_call({:find, id, type}, _from, graph) do
+        res = find_element(graph, id, type)
+        res = case find_element(graph, id, type) do
+          nil -> {:error, {:enotfound, type}}
+          element -> element
+        end
+        {:reply, res, graph}
+      end
+      # delete
+      def handle_call({:delete, id, type}, _from, graph) do
+        {res, new_graph} = case kind_of_element(graph, id) do
+          ^type -> {:ok, remove(type, id, graph)}
+          _ -> {{:error, {:enotfound, type}}, graph}
+        end
+        {:reply, res, new_graph}
+      end
+      # get
       def handle_call(:get, _from, graph) do
         {:reply, graph, graph}
       end
-
+      # add node
       def handle_call({:add_node, attrs}, _from, graph) do
         id = get_id
         new_node = %{ attrs: attrs }
         new_nodes = Map.put(graph.nodes, id, new_node)
         {:reply, {id, new_node}, %{ graph | nodes: new_nodes }}
       end
-
+      # add edge
       def handle_call({:add_edge, start_id, end_id, attrs}, _from, graph) do
         id = get_id
         new_edge = %{ start_node: start_id, end_node: end_id, attrs: attrs }
         new_edges = Map.put(graph.edges, id, new_edge)
         {:reply, {id, new_edge}, %{ graph | edges: new_edges }}
       end
-
+      # add cluster
       def handle_call({:add_cluster, node_ids}, _from, graph) do
         id = get_id
         new_cluster = %{ node_ids: node_ids }
         new_clusters = Map.put(graph.clusters, id, new_cluster)
         {:reply, {id, new_cluster}, %{ graph | clusters: new_clusters }}
       end
-
+      # add to cluster
       def handle_call({:add_to_cluster, cluster_id, node_ids}, _from, graph) do
         cluster = Map.get(graph.clusters, cluster_id)
         new_node_ids = (cluster.node_ids ++ node_ids) |> Enum.uniq
@@ -77,7 +88,7 @@ defmodule Graphvix.Callbacks do
         new_clusters = %{ graph.clusters | cluster_id => new_cluster }
         {:reply, new_cluster, %{ graph | clusters: new_clusters }}
       end
-
+      # remove from cluster
       def handle_call({:remove_from_cluster, cluster_id, node_ids}, _from, graph) do
         cluster = Map.get(graph.clusters, cluster_id)
         new_node_ids = (cluster.node_ids -- node_ids) |> Enum.uniq
@@ -86,9 +97,7 @@ defmodule Graphvix.Callbacks do
         {:reply, new_cluster, %{ graph | clusters: new_clusters }}
       end
 
-      def handle_call({:find, id}, _from, graph) do
-        {:reply, find_element(graph, id), graph}
-      end
+      ## PRIVATE
 
       defp update_attrs_for_element_in_graph(graph, id, element, key, attrs) do
         new_attrs = merge_without_nils(element.attrs, attrs)
@@ -123,6 +132,11 @@ defmodule Graphvix.Callbacks do
       defp find_element(graph, id) do
         Map.get(graph.nodes, id) || Map.get(graph.edges, id) || Map.get(graph.clusters, id)
       end
+      defp find_element(graph, id, type) do
+        with type_plural <- :"#{type}s" do
+          graph |> Map.get(type_plural) |> Map.get(id)
+        end
+      end
 
       defp kind_of_element(graph, id) do
         graph |> find_element(id) |> kind_of
@@ -136,6 +150,19 @@ defmodule Graphvix.Callbacks do
       defp remove_from_map(map, id) do
         {_, results} = Map.pop(map, id)
         results
+      end
+
+      defp remove(:node, id, graph) do
+        graph
+        |> remove_edges_attached_to_node(id)
+        |> remove_node_from_clusters(id)
+        |> update_graph_with_element_removed(:nodes, id)
+      end
+      defp remove(:edge, id, graph) do
+        update_graph_with_element_removed(graph, :edges, id)
+      end
+      defp remove(:cluster, id, graph) do
+        update_graph_with_element_removed(graph, :clusters, id)
       end
 
       defp get_id do

--- a/lib/graphvix/cluster.ex
+++ b/lib/graphvix/cluster.ex
@@ -79,7 +79,7 @@ defmodule Graphvix.Cluster do
   """
   @spec delete(pos_integer) :: :ok
   def delete(cluster_id) do
-    GenServer.cast(Graphvix.Graph, {:remove, cluster_id})
+    GenServer.call(Graphvix.Graph, {:delete, cluster_id, :cluster})
   end
 
   @doc """
@@ -93,7 +93,7 @@ defmodule Graphvix.Cluster do
   """
   @spec find(pos_integer) :: map | nil
   def find(cluster_id) do
-    GenServer.call(Graphvix.Graph, {:find, cluster_id})
+    GenServer.call(Graphvix.Graph, {:find, cluster_id, :cluster})
   end
 
   defp extract_ids([]), do: []

--- a/lib/graphvix/edge.ex
+++ b/lib/graphvix/edge.ex
@@ -73,7 +73,7 @@ defmodule Graphvix.Edge do
   """
   @spec delete(pos_integer) :: :ok
   def delete(edge_id) do
-    GenServer.cast(Graphvix.Graph, {:remove, edge_id})
+    GenServer.call(Graphvix.Graph, {:delete, edge_id, :edge})
   end
 
   @doc """
@@ -87,6 +87,6 @@ defmodule Graphvix.Edge do
   """
   @spec find(pos_integer) :: map | nil
   def find(edge_id) do
-    GenServer.call(Graphvix.Graph, {:find, edge_id})
+    GenServer.call(Graphvix.Graph, {:find, edge_id, :edge})
   end
 end

--- a/lib/graphvix/edge.ex
+++ b/lib/graphvix/edge.ex
@@ -59,7 +59,7 @@ defmodule Graphvix.Edge do
   """
   @spec update(pos_integer, Keyword.t) :: :ok
   def update(edge_id, attrs) do
-    GenServer.cast(Graphvix.Graph, {:update, edge_id, attrs})
+    GenServer.cast(Graphvix.Graph, {:update, :edge, edge_id, attrs})
   end
 
   @doc """

--- a/lib/graphvix/node.ex
+++ b/lib/graphvix/node.ex
@@ -36,7 +36,7 @@ defmodule Graphvix.Node do
   """
   @spec update(pos_integer, Keyword.t) :: :ok
   def update(node_id, attrs) do
-    GenServer.cast(Graphvix.Graph, {:update, node_id, attrs})
+    GenServer.cast(Graphvix.Graph, {:update, :node, node_id, attrs})
   end
 
   @doc """
@@ -51,7 +51,6 @@ defmodule Graphvix.Node do
   """
   @spec delete(pos_integer) :: :ok
   def delete(node_id) do
-    #GenServer.cast(Graphvix.Graph, {:remove, node_id})
     GenServer.call(Graphvix.Graph, {:delete, node_id, :node})
   end
 

--- a/lib/graphvix/node.ex
+++ b/lib/graphvix/node.ex
@@ -51,7 +51,8 @@ defmodule Graphvix.Node do
   """
   @spec delete(pos_integer) :: :ok
   def delete(node_id) do
-    GenServer.cast(Graphvix.Graph, {:remove, node_id})
+    #GenServer.cast(Graphvix.Graph, {:remove, node_id})
+    GenServer.call(Graphvix.Graph, {:delete, node_id, :node})
   end
 
   @doc """
@@ -65,6 +66,6 @@ defmodule Graphvix.Node do
   """
   @spec find(pos_integer) :: map | nil
   def find(node_id) do
-    GenServer.call(Graphvix.Graph, {:find, node_id})
+    GenServer.call(Graphvix.Graph, {:find, node_id, :node})
   end
 end

--- a/spec/graphvix/cluster_spec.exs
+++ b/spec/graphvix/cluster_spec.exs
@@ -39,7 +39,7 @@ defmodule Graphvix.ClusterSpec do
       {c_id, _c} = Cluster.new
 
       Cluster.delete(c_id)
-      expect Cluster.find(c_id) |> to(be_nil)
+      expect Cluster.find(c_id) |> to(eq {:error, {:enotfound, :cluster}})
     end
   end
 

--- a/spec/graphvix/edge_spec.exs
+++ b/spec/graphvix/edge_spec.exs
@@ -67,7 +67,7 @@ defmodule Graphvix.EdgeSpec do
       {e_id, _e} = Edge.new(n1, n2)
       Edge.delete(e_id)
 
-      expect Edge.find(e_id) |> to(be_nil)
+      expect Edge.find(e_id) |> to(eq {:error, {:enotfound, :edge}})
     end
   end
 

--- a/spec/graphvix/node_spec.exs
+++ b/spec/graphvix/node_spec.exs
@@ -43,8 +43,8 @@ defmodule Graphvix.NodeSpec do
       Node.delete(n2_id)
 
       expect Node.find(n_id) |> to(be_map)
-      expect Node.find(n2_id) |> to(be_nil)
-      expect Edge.find(e_id) |> to(be_nil)
+      expect Node.find(n2_id) |> to(eq {:error, {:enotfound, :node}})
+      expect Edge.find(e_id) |> to(eq {:error, {:enotfound, :edge}})
     end
 
     it "removes the node from any clusters that contain it" do
@@ -56,8 +56,17 @@ defmodule Graphvix.NodeSpec do
       Node.delete(n2_id)
 
       expect Node.find(n_id) |> to(be_map)
-      expect Node.find(n2_id) |> to(be_nil)
+      expect Node.find(n2_id) |> to(eq {:error, {:enotfound, :node}})
       expect Cluster.find(c_id) |>  Map.get(:node_ids) |> to(eq [n_id])
+    end
+
+    it "can only delete a node" do
+      Graph.restart
+      {n_id, _n} = Node.new
+      {n2_id, _n2} = Node.new
+      {e_id, _e} = Edge.new(n_id, n2_id)
+
+      expect Node.delete(e_id) |> to(eq {:error, {:enotfound, :node}})
     end
   end
 
@@ -66,6 +75,14 @@ defmodule Graphvix.NodeSpec do
       Graph.restart
       {n_id, n} = Node.new(label: "Start", color: "red")
       expect Node.find(n_id) |> to(eq n)
+    end
+
+    it "can only find a node" do
+      {n_id, _n} = Node.new
+      {n2_id, _n2} = Node.new
+      {e_id, _e} = Edge.new(n_id, n2_id)
+
+      expect Node.find(e_id) |> to(eq {:error, {:enotfound, :node}})
     end
   end
 end


### PR DESCRIPTION
Previously, find, update, and delete would find *any* element that matched by id, regardless of the calling module matched the element's type.

No longer!