### PR TITLE
Restart id agent after graph clear #14

### DIFF
--- a/lib/graphvix/callbacks.ex
+++ b/lib/graphvix/callbacks.ex
@@ -99,6 +99,7 @@ defmodule Graphvix.Callbacks do
       end
       def handle_cast(:clear, {state_pid, _}) do
         Graphvix.State.clear(state_pid)
+        clear_ids()
         {:noreply, {state_pid, nil}}
       end
       def handle_cast({:switch, name}, {state_pid, {current_name, current_graph}}) do

--- a/lib/graphvix/graph/helpers.ex
+++ b/lib/graphvix/graph/helpers.ex
@@ -5,6 +5,10 @@ defmodule Graphvix.Graph.Helpers do
     Graphvix.IdAgent.next
   end
 
+  def clear_ids do
+    Graphvix.IdAgent.clear
+  end
+
   def find_element(graph, id) do
     Map.get(graph.nodes, id) || Map.get(graph.edges, id) || Map.get(graph.clusters, id)
   end

--- a/lib/graphvix/id_agent.ex
+++ b/lib/graphvix/id_agent.ex
@@ -5,6 +5,11 @@ defmodule Graphvix.IdAgent do
     Agent.get_and_update(agent, &{&1, &1 + 1})
   end
 
+  def clear do
+    Agent.stop(agent)
+    agent()
+  end
+
   defp agent do
     case Agent.start(fn -> 1 end, name: :id_agent) do
       {:ok, agent} -> agent


### PR DESCRIPTION
After doing a `Graph.clear` this stops the id agent, reseting its state to 1.

## Warning

Testing the code at the master branch, switching graphs doesn't saves the graph and returns it. Reseting the ids could make new nodes to overlap ids while clearing and switching.

I was going to implement a function to update the ids, but can't test when switching doesn't work.